### PR TITLE
ci: lint des fichiers php avec parallel-lint

### DIFF
--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -1,0 +1,23 @@
+name: Lint PHP files
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  phplint:
+    name: Lint (PHP latest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Ref https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues/133#issuecomment-1367219847
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: latest
+          tools: parallel-lint
+
+      - name: Run lint
+        run: parallel-lint .


### PR DESCRIPTION
- uniquement avec la version PHP latest, même si on peut tester sur plusieurs versions cf https://github.com/shivammathur/setup-php/blob/main/examples/lumen.yml#L10
- sur l'event push sur master & sur l'event pull_request pour toutes les branches cf https://tjtelan.com/blog/github-actions-push-vs-pr-workflow/